### PR TITLE
add references to other rpsl4j- libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,19 +61,19 @@
 
       <div id="about">
          <h2>About</h2>
-         <p>RIPE NCC's <a href="https://github.com/RIPE-NCC/whois">whois tool</a> is written in Java, and includes a basic RPSL parser. This parser is embedded in a larger tool, and has a few limitations that make it unsuitable as a generic RPSL parsing library. Namely, it does not include a mechanism to extract values from attributes, and does not implement equality between field types. rpsl4j is a complete, generic RPSL parsing library based on the RIPE NCC whois code, with these limitations resolved.</p>
+         <p>RIPE NCC's <a href="https://github.com/RIPE-NCC/whois">whois tool</a> is written in Java, and includes a basic RPSL parser. This parser is embedded in a larger tool, and has a few limitations that make it unsuitable as a generic RPSL parsing library. Namely, it does not include a mechanism to extract values from attributes, and does not implement equality between field types. rpsl4j-parser is a complete, generic RPSL parsing library based on the RIPE NCC whois code, with these limitations resolved. The project also provides the rpsl4j-generator command-line application for generating network configurations based on RPSL documents. Currently rpsl4j-opendaylight is the only available configuration backend</p>
          <p>rpsl4j was originally developed as part of a project in the Australian National University's <a href="http://cs.anu.edu.au/TechLauncher/">TechLauncher</a> program.</p>
         <p>Each module includes an explanation of the issue in general, a presentation of a relevant vulnerability found by the trainer, and then a hands-on challenge to find and exploit a similar vulnerability in a sample application. The sample application is <a href="https://github.com/pentestingforfunandprofit/webbank">freely available on github</a>.</p>
       </div>
 
       <div id="download">
          <h2>Download</h2>
-         <p>A compiled rpsl4j JAR is available on <a href="http://search.maven.org/#artifactdetails|com.github.rpsl4j|rpsl4j-parser|1.80|jar">maven central</a>.</p>
+         <p>A compiled  <a href="http://search.maven.org/#artifactdetails|com.github.rpsl4j|rpsl4j-parser|1.80|jar">rpsl4j-parser</a> library, <a href="http://search.maven.org/#artifactdetails|com.github.rpsl4j|rpsl4j-generator|0.1|jar">rpsl4j-generator</a> CLI frontend and <a href="http://search.maven.org/#artifactdetails|com.github.rpsl4j|rpsl4j-parser|0.1|jar">rpsl4j-opendaylight</a> emitters are available on maven central.</p>
       </div>
 
       <div id="code">
          <h2>Source code</h2>
-         <p>The source code is <a href="https://github.com/rpsl4j/rpsl4j-parser">freely available on github</a>.</p>
+         <p>The source code for each artifact is <a href="https://github.com/rpsl4j">freely available on github</a>.</p>
       </div>
 
       <div id="contributors">
@@ -102,4 +102,3 @@
 
   </body>
 </html>
-


### PR DESCRIPTION
We now have 3 different libraries under rpsl4j (the generator application and opendaylight backend). I've added references and links to these other libraries.

I would have PR'd directly on the repo but I do not have commit rights on it. Can these be added?
